### PR TITLE
Med kit pick up fixed

### DIFF
--- a/gameObjects.py
+++ b/gameObjects.py
@@ -352,7 +352,8 @@ class Health(BaseGameObject):
 
     def collide(self, other):
         if isinstance(other, Player):
-            self.is_alive = False
+            if other.health != other.maxHealth:
+                self.is_alive = False
 
     def update(self):
         pass
@@ -447,7 +448,8 @@ class Player(Creature):
             self.eat(other.amount)
 
         if isinstance(other, Health):
-            self.heal(other.healthAmount, True)
+            if self.health != self.maxHealth:
+                self.heal(other.healthAmount, True)
 
         if isinstance(other, Bones):
             self.bones += 1

--- a/main.py
+++ b/main.py
@@ -82,8 +82,8 @@ class App:
                 bList = [x for x in self.gameObjects.getNearbyElements(a) if isinstance(x, each[1])]
                 for b in bList:
                     if a != b and collision(a, b):
-                        a.collide(b)
                         b.collide(a)
+                        a.collide(b)
 
     def numType(self, t):
         return len([x for x in self.gameObjects if isinstance(x, t)])


### PR DESCRIPTION
Added functionality to the Health object (med kit) so it would not be picked if the health of the player is at maximum.
Also had to change the order of collision from
1. a.collide(b) 
2. b.collide(a)
To:
1. b.collide(a)
2. a.collide(b)
This prevents the case when health of the player is not at full when colliding with the medkit, but will be restored to full as a result of the medkit. It caused the player to heal, but as player was healed, the medkit remained on the ground.